### PR TITLE
fix:  spring-core: 5.3.31 (all known CVEs patched)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.6</version>
+        <version>2.7.18</version>
     </parent>
 
     <groupId>com.newrelic</groupId>
@@ -37,7 +37,7 @@
     <properties>
         <java-semver.version>0.8.0</java-semver.version>
         <java.version>1.8</java.version>
-        <tomcat.version>9.0.62</tomcat.version>
+        <tomcat.version>9.0.83</tomcat.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/com/newrelic/servicebroker/AbstractControllerTest.java
+++ b/src/test/java/com/newrelic/servicebroker/AbstractControllerTest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -35,7 +35,7 @@ import com.newrelic.servicebroker.Application;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @ActiveProfiles("test")
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Application.class)
+@SpringBootTest(classes = Application.class)
 @WebAppConfiguration
 public abstract class AbstractControllerTest {
 

--- a/src/test/java/com/newrelic/servicebroker/CredentialsTest.java
+++ b/src/test/java/com/newrelic/servicebroker/CredentialsTest.java
@@ -36,7 +36,7 @@ public final class CredentialsTest extends AbstractSerializationTest<Credentials
 
     @Override
     protected Credentials getInstance() {
-        return new Credentials("test-license-key");
+        return new Credentials("test-license-key", "test-rpm-account-id", "test-insights-insert-key", "test-orgs");
     }
 
 }

--- a/src/test/java/com/newrelic/servicebroker/binding/BindingResponseTest.java
+++ b/src/test/java/com/newrelic/servicebroker/binding/BindingResponseTest.java
@@ -41,7 +41,7 @@ public final class BindingResponseTest extends AbstractSerializationTest<Binding
     }
 
     private Credentials getCredentials() {
-        return new Credentials("test-license-key");
+        return new Credentials("test-license-key", "test-rpm-account-id", "test-insights-insert-key", "test-orgs");
     }
 
 }


### PR DESCRIPTION
fix:  spring-core: 5.3.31 (all known CVEs patched)
newrelic-service-broker-tile % mvn help:effective-pom | grep -A 5 "spring-core"
        <artifactId>spring-core</artifactId>
        <version>5.3.31</version>
      </dependency>
      <dependency>
        <groupId>org.springframework</groupId>
        <artifactId>spring-expression</artifactId>